### PR TITLE
Card layout alignment adjustments

### DIFF
--- a/src/Seq.App.Teams.AdaptiveCard/Resources/default-template.json
+++ b/src/Seq.App.Teams.AdaptiveCard/Resources/default-template.json
@@ -38,9 +38,9 @@
                 },
                 {
                     "type": "FactSet",
-                    "$data": "${indicesAndValues(Properties)}",
                     "facts": [
                         {
+                            "$data": "${indicesAndValues(Properties)}",
                             "title": "**${_nomd(index)}**",
                             "value": "${_jsonPrettify(if(exists(value), _nomd(value), ''))}"
                         }
@@ -203,7 +203,7 @@
                 },
                 {
                     "type": "Column",
-                    "width": "stretch",
+                    "width": "auto",
                     "items": [
                         {
                             "type": "ActionSet",


### PR DESCRIPTION
The current default card template has some misalignments in its current state. This PR includes 2 tweaks to resolve them:

- Moves the `$data` property from the fact sheet definition to inside the `facts` array. This ensures all the facts are added to a single fact sheet, causing proper alingment.
- Changes `width` to `auto` for the column hosting the `[Open Seq]` button. This is essentially a workaround for a rendering issue in Teams, which apparently ignores the button's `horizontalAlignment` property.

> [!NOTE]
> Pardon me if the current layout is intentional. If so, feel free to simply delete this PR 😸 

### Before

![image](https://github.com/user-attachments/assets/2ae2785c-5241-462a-a91c-b94a310722c3)

### After

<sup>(red annotations added for illustration)</sup>
![image](https://github.com/user-attachments/assets/c84da8f7-bb37-4efc-8578-44448018b6ed)