### PR TITLE
Fix alert title link in default template (#23)

### DIFF
--- a/src/Seq.App.Teams.AdaptiveCard/Resources/default-template.json
+++ b/src/Seq.App.Teams.AdaptiveCard/Resources/default-template.json
@@ -59,7 +59,7 @@
             "items": [
                 {
                     "type": "TextBlock",
-                    "text": "Alert condition triggered by [${_nomd(Properties.NamespacedAlertTitle)}](Alert.Url)",
+                    "text": "Alert condition triggered by [${_nomd(Properties.NamespacedAlertTitle)}](${Properties.Alert.Url})",
                     "wrap": true
                 },
                 {

--- a/tests/Seq.App.Teams.AdaptiveCard.Tests/TemplateTests.cs
+++ b/tests/Seq.App.Teams.AdaptiveCard.Tests/TemplateTests.cs
@@ -57,7 +57,7 @@ data",
             { "BaseUri", "http://localhost" },
         };
 
-        AssertDefaultTemplateExpands(data);
+        _ = AssertDefaultTemplateExpands(data);
     }
 
     [Test]
@@ -78,7 +78,7 @@ data",
             { "BaseUri", "http://localhost" },
         };
 
-        AssertDefaultTemplateExpands(data);
+        _ = AssertDefaultTemplateExpands(data);
     }
 
     [Test]
@@ -135,7 +135,11 @@ data",
             { "BaseUri", "http://localhost" },
         };
 
-        AssertDefaultTemplateExpands(data);
+        var result = AssertDefaultTemplateExpands(data);
+
+        // https://github.com/MaceWindu/Seq.App.Teams.AdaptiveCard/issues/23
+        // the alert title link must reference the interpolated ${Properties.Alert.Url}, not a literal
+        Assert.That(result, Does.Contain("http://localhost:80/#/alerts/alert-463"));
     }
 
     [Test]
@@ -182,7 +186,7 @@ data",
             { "BaseUri", "http://localhost" },
         };
 
-        AssertDefaultTemplateExpands(data);
+        _ = AssertDefaultTemplateExpands(data);
     }
 
     [Test(Description = "https://github.com/microsoft/botbuilder-dotnet/issues/6814")]
@@ -239,10 +243,10 @@ data",
             { "BaseUri", "http://localhost" },
         };
 
-        AssertDefaultTemplateExpands(data);
+        _ = AssertDefaultTemplateExpands(data);
     }
 
-    private static void AssertDefaultTemplateExpands(Dictionary<string, object?> data)
+    private static string AssertDefaultTemplateExpands(Dictionary<string, object?> data)
     {
         using var stream = typeof(TeamsApp).Assembly.GetManifestResourceStream("Seq.App.Teams.AdaptiveCard.Resources.default-template.json")!;
         using var reader = new StreamReader(stream);
@@ -255,5 +259,7 @@ data",
         Assert.That(errors, Is.Empty);
         Assert.That(result.Count(c => c == '$'), Is.EqualTo(1));
         Assert.DoesNotThrow(() => JsonDocument.Parse(result));
+
+        return result;
     }
 }


### PR DESCRIPTION
Fixes #23.

The default alert template's title used a literal `(Alert.Url)` as the markdown link target instead of the interpolated `(${Properties.Alert.Url})`. AdaptiveCard then rendered a broken link, which made the alert title show with no visible text in Teams.

## Change
- `Resources/default-template.json`: `](Alert.Url)` → `](${Properties.Alert.Url})` (consistent with `${Properties.NamespacedAlertTitle}` on the same line)
- `TemplateTests`: the shared helper now returns the rendered card and `TestAlertTemplate` asserts the output contains the alert URL — added test-first (it fails on the old literal, passes with the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
