### PR TITLE
Release 2.5.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
     <PropertyGroup Label="Versioning">
         <!--bump to the next version after each release-->
-        <Version>2.4.0</Version>
+        <Version>2.5.0</Version>
         <!--CI overrides VersionSuffix (e.g. -rc.<build>) for dev feeds and sets ApplyVersionSuffix=false for release-->
         <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">-local.1</VersionSuffix>
         <ApplyVersionSuffix Condition=" '$(ApplyVersionSuffix)' == '' ">true</ApplyVersionSuffix>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ If you design your custom templates, you should use `AdaptiveCard` schema versio
 
 Default template source: [default-template.json](https://github.com/MaceWindu/Seq.App.Teams.AdaptiveCard/blob/master/src/Seq.App.Teams.AdaptiveCard/Resources/default-template.json). Used when no template specified.
 
+By default the header is colored using a generated background image (via the `_colorUri` function), which gives distinct per-level colors but can render slowly in Teams ([#27](https://github.com/MaceWindu/Seq.App.Teams.AdaptiveCard/issues/27)). Enable the `Use Teams styles` setting to switch to [default-template-styles.json](https://github.com/MaceWindu/Seq.App.Teams.AdaptiveCard/blob/master/src/Seq.App.Teams.AdaptiveCard/Resources/default-template-styles.json), which uses native Teams container styles instead: it renders instantly and adapts to light/dark theme, but only a small set of pale theme colors is available. This setting only affects the built-in template — it is ignored when a custom template is specified.
+
 ### Payload Examples
 
 Those examples could be used with `AdaptiveCard` designer.

--- a/src/Seq.App.Teams.AdaptiveCard/Resources/default-template-styles.json
+++ b/src/Seq.App.Teams.AdaptiveCard/Resources/default-template-styles.json
@@ -1,0 +1,221 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+    "msteams": {
+        "width": "full"
+    },
+    "body": [
+        {
+            "type": "Container",
+            "style": "${if(equals(Level,'Fatal'),'attention',if(equals(Level,'Error'),'attention',if(equals(Level,'Warning'),'warning',if(equals(Level,'Information'),'accent','default'))))}",
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "**${Level}**",
+                    "wrap": true,
+                    "size": "ExtraLarge"
+                }
+            ]
+        },
+        {
+            "type": "TextBlock",
+            "text": "{{DATE(${formatDateTime(TimeStamp,'yyyy-MM-ddTHH:mm:ssZ')},SHORT)}} {{TIME(${formatDateTime(TimeStamp,'yyyy-MM-ddTHH:mm:ssZ')})}}",
+            "wrap": true,
+            "color": "Attention"
+        },
+        {
+            "type": "Container",
+            "$when": "${not(equals(EventType,2716299265))}",
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "**${_nomd(Message)}**",
+                    "wrap": true
+                },
+                {
+                    "type": "FactSet",
+                    "facts": [
+                        {
+                            "$data": "${indicesAndValues(Properties)}",
+                            "title": "**${index}**",
+                            "value": "${_jsonPrettify(if(exists(value), value, ''))}"
+                        }
+                    ]
+                },
+                {
+                    "type": "TextBlock",
+                    "$when": "${exists(Exception)}",
+                    "text": "${_nomd(Exception)}"
+                }
+            ]
+        },
+        {
+            "type": "Container",
+            "$when": "${equals(EventType,2716299265)}",
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Alert condition triggered by [${_nomd(Properties.NamespacedAlertTitle)}](${Properties.Alert.Url})",
+                    "wrap": true
+                },
+                {
+                    "type": "Container",
+                    "$when": "${exists(Properties.Source.Results)}",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "**Results**",
+                            "wrap": true
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "$data": "${if(exists(Properties.Source.Results), indicesAndValues(Properties.Source.Results[0]), null)}",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "**${_nomd(value)}**",
+                                            "wrap": true
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "$data": "${if(exists(Properties.Source.Results), skip(Properties.Source.Results, 1), null)}",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "$data": "${if(exists($data), indicesAndValues($data), null)}",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "${_jsonPrettify(_nomd(value))}",
+                                            "wrap": true
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "[Explore detected results in Seq](${Properties.Source.ResultsUrl})",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Container",
+                    "$when": "${exists(Properties.Source.ContributingEvents)}",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "**Contributing events**",
+                            "wrap": true
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "**Time**",
+                                            "wrap": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "**Message**",
+                                            "wrap": true
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "$data": "${if(exists(Properties.Source.ContributingEvents), skip(Properties.Source.ContributingEvents, 1), null)}",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "[${$data[1]}](${$root.BaseUri}#/events?filter=@Id%3D'${$data[0]}'&show=expanded)",
+                                            "wrap": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {
+                                            "type": "TextBlock",
+                                            "text": "${_jsonPrettify(_nomd($data[2]))}",
+                                            "wrap": true
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "ActionSet",
+                            "actions": [
+                                {
+                                    "type": "Action.OpenUrl",
+                                    "$when": "${not(equals(EventType,2716299265))}",
+                                    "title": "View Event in Seq",
+                                    "url": "${BaseUri}#/events?filter=@Id%3D'${Id}'&show=expanded"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "ActionSet",
+                            "actions": [
+                                {
+                                    "type": "Action.OpenUrl",
+                                    "title": "Open Seq",
+                                    "url": "${BaseUri}"
+                                }
+                            ],
+                            "horizontalAlignment": "right"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/Seq.App.Teams.AdaptiveCard/Seq.App.Teams.AdaptiveCard.csproj
+++ b/src/Seq.App.Teams.AdaptiveCard/Seq.App.Teams.AdaptiveCard.csproj
@@ -41,6 +41,7 @@
 
     <ItemGroup>
       <EmbeddedResource Include="Resources/default-template.json" />
+      <EmbeddedResource Include="Resources/default-template-styles.json" />
     </ItemGroup>
 
     <ItemGroup Label="Package files">

--- a/src/Seq.App.Teams.AdaptiveCard/TeamsApp.OnAttached.cs
+++ b/src/Seq.App.Teams.AdaptiveCard/TeamsApp.OnAttached.cs
@@ -27,7 +27,10 @@ public sealed partial class TeamsApp
             _httpClientHandler.UseProxy = false;
         }
 
-        using var stream = GetType().Assembly.GetManifestResourceStream("Seq.App.Teams.AdaptiveCard.Resources.default-template.json");
+        var resourceName = UseTeamsStyles
+            ? "Seq.App.Teams.AdaptiveCard.Resources.default-template-styles.json"
+            : "Seq.App.Teams.AdaptiveCard.Resources.default-template.json";
+        using var stream = GetType().Assembly.GetManifestResourceStream(resourceName);
         using var reader = new StreamReader(stream);
         _defaultTemplate = reader.ReadToEnd();
 

--- a/src/Seq.App.Teams.AdaptiveCard/TeamsApp.Settings.cs
+++ b/src/Seq.App.Teams.AdaptiveCard/TeamsApp.Settings.cs
@@ -48,6 +48,12 @@ public sealed partial class TeamsApp
     public string? CardTemplate { get; set; }
 
     [SeqAppSetting(
+        DisplayName = "Use Teams styles",
+        HelpText = "Use Teams container styles for the header background instead of a generated background image. Renders faster but only a small set of pale theme colors is available. Only affects the built-in template — ignored when a custom AdaptiveCard template is set. See https://github.com/MaceWindu/Seq.App.Teams.AdaptiveCard/issues/27",
+        IsOptional = true)]
+    public bool UseTeamsStyles { get; set; }
+
+    [SeqAppSetting(
         DisplayName = "Excluded Properties",
         HelpText = "Specify properties to exclude from template model. Each property should be specified on separate line. Format: [property-name]+. `\\`, `]`, `\\r` and `\\n` symbols in property name should be escaped with \\: `\\\\`, `\\]`, `\\r`, `\\n`",
         InputType = SettingInputType.LongText,

--- a/tests/Seq.App.Teams.AdaptiveCard.Tests/TemplateTests.cs
+++ b/tests/Seq.App.Teams.AdaptiveCard.Tests/TemplateTests.cs
@@ -14,6 +14,8 @@ namespace Seq.App.Teams.Tests;
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
 internal sealed class TemplateTests
 {
+    private const string StylesResource = "Seq.App.Teams.AdaptiveCard.Resources.default-template-styles.json";
+
     private static readonly Event<LogEventData> _event = new(
         id: "event-id",
         eventType: uint.MaxValue,
@@ -58,6 +60,7 @@ data",
         };
 
         _ = AssertDefaultTemplateExpands(data);
+        _ = AssertDefaultTemplateExpands(data, StylesResource);
     }
 
     [Test]
@@ -79,6 +82,7 @@ data",
         };
 
         _ = AssertDefaultTemplateExpands(data);
+        _ = AssertDefaultTemplateExpands(data, StylesResource);
     }
 
     [Test]
@@ -136,6 +140,7 @@ data",
         };
 
         var result = AssertDefaultTemplateExpands(data);
+        _ = AssertDefaultTemplateExpands(data, StylesResource);
 
         // https://github.com/MaceWindu/Seq.App.Teams.AdaptiveCard/issues/23
         // the alert title link must reference the interpolated ${Properties.Alert.Url}, not a literal
@@ -187,6 +192,7 @@ data",
         };
 
         _ = AssertDefaultTemplateExpands(data);
+        _ = AssertDefaultTemplateExpands(data, StylesResource);
     }
 
     [Test(Description = "https://github.com/microsoft/botbuilder-dotnet/issues/6814")]
@@ -244,11 +250,14 @@ data",
         };
 
         _ = AssertDefaultTemplateExpands(data);
+        _ = AssertDefaultTemplateExpands(data, StylesResource);
     }
 
-    private static string AssertDefaultTemplateExpands(Dictionary<string, object?> data)
+    private static string AssertDefaultTemplateExpands(
+        Dictionary<string, object?> data,
+        string resourceName = "Seq.App.Teams.AdaptiveCard.Resources.default-template.json")
     {
-        using var stream = typeof(TeamsApp).Assembly.GetManifestResourceStream("Seq.App.Teams.AdaptiveCard.Resources.default-template.json")!;
+        using var stream = typeof(TeamsApp).Assembly.GetManifestResourceStream(resourceName)!;
         using var reader = new StreamReader(stream);
         var template = reader.ReadToEnd();
 


### PR DESCRIPTION
Release PR: promotes `master` to `release`, triggering the stable NuGet publish of **2.5.0** to nuget.org.

## Included since 2.4.0
- Opt-in `Use Teams styles` setting + `default-template-styles.json` — style-based header coloring that renders instantly in Teams, as an alternative to the image-based default (#27, #28).
- Version bump 2.4.0 → 2.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)