### PR TITLE
Use static MIT license badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Seq.App.Teams.AdaptiveCard [![Build Status](https://img.shields.io/azure-devops/build/macewindu/projects/2/master?label=build%20(master))](https://dev.azure.com/macewindu/projects/_build/latest?definitionId=2&branchName=master) [![NuGet](https://img.shields.io/nuget/v/Seq.App.Teams.AdaptiveCard.svg)](https://www.nuget.org/packages/Seq.App.Teams.AdaptiveCard/) [![License](https://img.shields.io/github/license/MaceWindu/Seq.App.Teams.AdaptiveCard)](LICENSE.txt)
+# Seq.App.Teams.AdaptiveCard [![Build Status](https://img.shields.io/azure-devops/build/macewindu/projects/2/master?label=build%20(master))](https://dev.azure.com/macewindu/projects/_build/latest?definitionId=2&branchName=master) [![NuGet](https://img.shields.io/nuget/v/Seq.App.Teams.AdaptiveCard.svg)](https://www.nuget.org/packages/Seq.App.Teams.AdaptiveCard/) [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE.txt)
 
 Seq alerting application for Microsoft Teams with AdaptiveCard support. Based on [Seq.App.Teams](https://github.com/AntoineGa/Seq.App.Teams) application.
 


### PR DESCRIPTION
The README's license badge renders **"license invalid"** on the repo page. It uses the dynamic shields.io `github/license` endpoint, which does a live GitHub API lookup and intermittently returns `invalid` when that lookup rate-limits/hiccups (GitHub itself detects the license correctly as MIT).

Replaces it with a static MIT badge — always renders `license | MIT`, still links to `LICENSE.txt`, no live API dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)